### PR TITLE
Fix typo

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -245,7 +245,7 @@ function encodeString(str: string) {
   // This is a giant dict of strings that map to token IDs
   const encoder = JSON.parse(fs.readFileSync('weights/encoder.json', 'utf8'));
 
-  // A weird quirk of GPT2's tokenization is that they map control and whitespace characters up by 255 to make them printable, not entirely
+  // A weird quirk of GPT2's tokenization is that they map control and whitespace characters up by 256 to make them printable, not entirely
   // clear why this is but perhaps so that everything can confidently be printable while debugging without things (for example) clearing your terminal
   const [byteMapping, _] = bytesToUnicode();
   str = str.split('').map((c) => byteMapping[c.charCodeAt(0)]).join('');


### PR DESCRIPTION
Fixes a comment about encoding padding, it's padded by 0x100.
Also the `while` loop right after that can be replaced by a much faster lookup taking advantage of a token length distribution (max in gpt2 is 128, there are only a few tokens between sizes 50..128). If we precompute the sizes to lookup, we can slice the input string into 128-sized chunks -  for example, input `we are` would be one chunk with size 6. We then look up the encoder.json table for the `we are` token, if not found we search for `we ar`, `we a`, `we `, `we`, `w`.  This way we solve each chunk in `128 - m` (`m` being the count of indexes between 1..128 where there are no tokens of given size) O(1) operations instead of iterating the entire dictionary repeatedly and slow comparing via `startsWith`.

There are only 33 unique token sizes in the gpt2 encoder:
```
[
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
  9,
  10,
  11,
  12,
  13,
  14,
  15,
  16,
  17,
  18,
  19,
  20,
  21,
  23,
  24,
  25,
  32,
  33,
  34,
  48,
  56,
  64,
  65,
  66,
  128
]
```

C# implementation of proposed algorithm:
```cs
encoder = JsonConvert.DeserializeObject<Dictionary<string, int>>(File.ReadAllText($"{settings.EncoderPath}/encoder.json"))!;
nonEmptyTokenLengths = JsonConvert.DeserializeObject<List<int>>(File.ReadAllText($"{settings.EncoderPath}/encoderMeta.json"))!;
maxNonEmptyTokenSize = nonEmptyTokenLengths.Max();

public List<int> Tokenize(string input)
{
    List<int> tokens = new List<int>();
    int totalLen = 0;

    int Solve(string chunk)
    {
        string cpy = chunk;
        int pos = nonEmptyTokenLengths.IndexOf(chunk.Length);

        if (pos == -1)
        {
            int closest = nonEmptyTokenLengths.LastOrDefault(x => x <= chunk.Length);
            string subA = chunk[..closest];
            
            int solvedLen = Solve(subA);
            Solve(cpy[solvedLen..]);

            return 0;
        }

        while (pos >= 0)
        {
            if (encoder.TryGetValue(chunk, out int tokenIndex))
            {
                tokens.Add(tokenIndex);
                totalLen += chunk.Length;
                break;
            }

            pos--;
            chunk = chunk[..nonEmptyTokenLengths[pos]];
        }

        return chunk.Length;
    }

    while (totalLen < input.Length)
    {
        string sub = input[totalLen..];     
        Solve(sub);   
    }

    return tokens;
} 
```